### PR TITLE
Add Python port of L1 Voronoi generator

### DIFF
--- a/python_ai/demo.py
+++ b/python_ai/demo.py
@@ -1,0 +1,83 @@
+import random
+import colorsys
+import matplotlib.pyplot as plt
+from matplotlib.patches import Polygon
+from voronoi import generateL1Voronoi
+
+
+def random_normal(sharpness):
+    return sum(random.random() for _ in range(sharpness)) / sharpness
+
+
+def get_cell_color(index, total):
+    hue = (index * 0.618033988749895) % 1.0
+    r, g, b = colorsys.hsv_to_rgb(hue, 0.5, 0.95)
+    return (r, g, b)
+
+
+def get_color(size):
+    return {
+        4: '#4286f4',
+        8: '#44f453',
+        16: '#931d78',
+        32: '#ff3c35',
+        64: '#f4ad42',
+        128: '#009182',
+        256: '#993300',
+        512: '#669999',
+        1024: '#800000',
+        2048: '#333300',
+    }.get(size, '#000000')
+
+
+def main():
+    width = 400
+    height = 400
+    num_points = 89
+
+    random.seed(1)
+    raw = [[int(random_normal(2) * width), int(random_normal(2) * height)] for _ in range(num_points)]
+    sites = [list(p) for p in raw]
+
+    vector_points = generateL1Voronoi(sites, width, height)
+
+    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 7))
+
+    drawn_bisectors = set()
+    for i, site in enumerate(vector_points):
+        poly_pts = [(x, height - y) for x, y in site['polygonPoints']]
+        poly = Polygon(poly_pts, closed=True, edgecolor='black',
+                       facecolor=get_cell_color(i, len(vector_points)), linewidth=0.5, alpha=0.8)
+        ax1.add_patch(poly)
+        ax1.plot(site['site'][0], height - site['site'][1], 'ko', markersize=3)
+
+        for bisector in site['bisectors']:
+            bid = id(bisector)
+            if bid in drawn_bisectors:
+                continue
+            drawn_bisectors.add(bid)
+            pts = [(x, height - y) for x, y in bisector['points']]
+            color = get_color(bisector.get('mergeLine', 0))
+            ax2.plot([p[0] for p in pts], [p[1] for p in pts],
+                     color=color, linewidth=0.8)
+        ax2.plot(site['site'][0], height - site['site'][1], 'ko', markersize=2)
+
+    ax1.set_xlim(0, width)
+    ax1.set_ylim(0, height)
+    ax1.set_aspect('equal')
+    ax1.set_title('Diagram')
+
+    ax2.set_xlim(0, width)
+    ax2.set_ylim(0, height)
+    ax2.set_aspect('equal')
+    ax2.set_title('Merge Process')
+
+    plt.tight_layout()
+    plt.savefig('python_ai/voronoi_demo.png', dpi=150)
+    plt.close()
+    print("Diagram saved to python_ai/voronoi_demo.png")
+    print("Sites:", len(vector_points))
+
+
+if __name__ == "__main__":
+    main()

--- a/python_ai/test_voronoi.py
+++ b/python_ai/test_voronoi.py
@@ -1,0 +1,216 @@
+import unittest
+import random
+import sys
+
+sys.path.insert(0, ".")
+from voronoi import (
+    bisectorIntersection,
+    findL1Bisector,
+    samePoint,
+    generateVoronoiPoints,
+    cleanData,
+    generateL1Voronoi,
+    distance,
+)
+
+
+class TestBisectorIntersection(unittest.TestCase):
+    def _s(self, x, y):
+        return {"site": [x, y], "bisectors": []}
+
+    def test_normal_shared_site(self):
+        A = self._s(4, 6)
+        B = self._s(3, 10)
+        C1 = self._s(10, 6)
+        C2 = self._s(10, 6)
+        bAC = findL1Bisector(A, C1, 30, 30)
+        bBC = findL1Bisector(B, C2, 30, 30)
+        P = bisectorIntersection(bAC, bBC)
+        self.assertIsInstance(P, list)
+        self.assertEqual(len(P), 2)
+
+    def test_non_shared_bisectors(self):
+        A = self._s(0, 0)
+        B = self._s(10, 0)
+        C = self._s(0, 20)
+        D = self._s(10, 20)
+        bAB = findL1Bisector(A, B, 30, 30)
+        bCD = findL1Bisector(C, D, 30, 30)
+        P = bisectorIntersection(bAB, bCD)
+        self.assertTrue(P is False or isinstance(P, list))
+
+    def test_no_sites_key(self):
+        zline = {"points": [[-4, 4], [200, 4]]}
+        C = self._s(-8, -2)
+        bBC = findL1Bisector(self._s(-1, 1), C, 200, 200)
+        P = bisectorIntersection(zline, bBC)
+        self.assertTrue(P is False or isinstance(P, list))
+
+
+class TestGenerateVoronoiPoints(unittest.TestCase):
+    def test_basic(self):
+        pts = [[4, 6], [3, 10], [10, 6], [1, 2]]
+        result = generateVoronoiPoints(pts, 30, 30, distance)
+        self.assertEqual(len(result), 900)
+
+
+class TestCleanData(unittest.TestCase):
+    def test_nudge(self):
+        data = [[4, 6], [6, 4]]
+        cleanData(data)
+        self.assertNotEqual(data[1], [6, 4])
+
+
+class TestGenerateL1Voronoi(unittest.TestCase):
+    def test_four_sites(self):
+        sites = [[4, 6], [3, 10], [10, 6], [1, 2]]
+        result = generateL1Voronoi(sites, 30, 30, nudgeData=True)
+        self.assertEqual(len(result), 4)
+        for site in result:
+            self.assertIn("d", site)
+            self.assertIn("neighbors", site)
+            self.assertIn("polygonPoints", site)
+            self.assertGreaterEqual(len(site["polygonPoints"]), 3)
+
+    def test_16_random_sites(self):
+        random.seed(42)
+        sites = [
+            [int(random.random() * 400), int(random.random() * 400)] for _ in range(16)
+        ]
+        result = generateL1Voronoi(sites, 400, 400, nudgeData=True)
+        self.assertEqual(len(result), 16)
+        for site in result:
+            self.assertGreaterEqual(len(site["neighbors"]), 1)
+
+
+class TestRandomStress(unittest.TestCase):
+    @staticmethod
+    def _random_normal(sharpness):
+        return sum(random.random() for _ in range(sharpness)) / sharpness
+
+    def _gen_sites(self, seed, n):
+        random.seed(seed)
+        return [
+            [int(self._random_normal(2) * 400), int(self._random_normal(2) * 400)]
+            for _ in range(n)
+        ]
+
+    def test_89_sites(self):
+        sites = self._gen_sites(1, 89)
+        result = generateL1Voronoi(sites, 400, 400)
+        self.assertGreaterEqual(len(result), 1)
+        for site in result:
+            self.assertGreaterEqual(len(site["neighbors"]), 1)
+            self.assertGreaterEqual(len(site["polygonPoints"]), 3)
+            self.assertIn("d", site)
+            self.assertTrue(site["d"].startswith("M "))
+            self.assertTrue(site["d"].endswith(" Z"))
+
+    def test_multi_seed_stress(self):
+        for seed in range(20):
+            sites = self._gen_sites(seed, 67)
+            result = generateL1Voronoi(sites, 400, 400)
+            for site in result:
+                self.assertGreaterEqual(len(site["neighbors"]), 1)
+                self.assertGreaterEqual(len(site["polygonPoints"]), 3)
+                for bisector in site["bisectors"]:
+                    pts = bisector["points"]
+                    self.assertGreaterEqual(
+                        len(pts), 2, f"seed {seed}: bisector has <2 points"
+                    )
+                    for k in range(len(pts) - 1):
+                        self.assertFalse(
+                            samePoint(pts[k], pts[k + 1]),
+                            f"seed {seed}: zero-length segment in bisector",
+                        )
+
+    def test_intersection_correctness(self):
+        for seed in range(10):
+            sites_raw = self._gen_sites(seed, 30)
+            site_objs = [{"site": p, "bisectors": []} for p in sites_raw]
+            for i in range(len(site_objs)):
+                for j in range(i + 1, len(site_objs)):
+                    for k in range(len(site_objs)):
+                        if k == i or k == j:
+                            continue
+                        A = site_objs[i]
+                        B = site_objs[j]
+                        C = site_objs[k]
+                        try:
+                            bAC = findL1Bisector(A, C, 400, 400)
+                        except ValueError:
+                            continue
+                        try:
+                            bBC = findL1Bisector(B, C, 400, 400)
+                        except ValueError:
+                            continue
+                        P = bisectorIntersection(bAC, bBC)
+                        if P is False:
+                            continue
+                        self.assertTrue(
+                            self._point_on_bisector(P, bAC),
+                            f"seed {seed}: P={P} not on bAC {A['site']}-{C['site']}",
+                        )
+                        self.assertTrue(
+                            self._point_on_bisector(P, bBC),
+                            f"seed {seed}: P={P} not on bBC {B['site']}-{C['site']}",
+                        )
+
+    def test_polygon_simple(self):
+        for seed in range(10):
+            sites = self._gen_sites(seed, 20)
+            result = generateL1Voronoi(sites, 400, 400)
+            for site in result:
+                pts = site["polygonPoints"]
+                n = len(pts)
+                for a in range(n):
+                    for c in range(a + 2, n):
+                        if a == 0 and c == n - 1:
+                            continue
+                        b = (a + c) // 2
+                        if self._segments_cross(
+                            pts[a], pts[b], pts[b if b + 1 < n else 0], pts[c]
+                        ):
+                            self.fail(
+                                f"seed {seed} self-intersecting polygon at site {site['site']}"
+                            )
+
+    @staticmethod
+    def _segments_cross(p0, p1, p2, p3):
+        d1 = (p1[0] - p0[0], p1[1] - p0[1])
+        d2 = (p3[0] - p2[0], p3[1] - p2[1])
+        denom = d2[1] * d1[0] - d2[0] * d1[1]
+        if denom == 0:
+            return False
+        ua = (d2[0] * (p0[1] - p2[1]) - d2[1] * (p0[0] - p2[0])) / denom
+        ub = (d1[0] * (p0[1] - p2[1]) - d1[1] * (p0[0] - p2[0])) / denom
+        return 0 < ua < 1 and 0 < ub < 1
+
+    @staticmethod
+    def _point_on_bisector(pt, bisector):
+        def point_on_segment(p, s0, s1):
+            dx = s1[0] - s0[0]
+            dy = s1[1] - s0[1]
+            if dx == 0 and dy == 0:
+                return p[0] == s0[0] and p[1] == s0[1]
+            if abs(dx) > abs(dy):
+                t = (p[0] - s0[0]) / dx
+            elif abs(dx) < abs(dy):
+                t = (p[1] - s0[1]) / dy
+            else:
+                t = (p[0] - s0[0]) / dx
+            if not (0 <= t <= 1):
+                return False
+            return (
+                abs(p[0] - (s0[0] + t * dx)) < 1e-9
+                and abs(p[1] - (s0[1] + t * dy)) < 1e-9
+            )
+
+        for k in range(len(bisector["points"]) - 1):
+            if point_on_segment(pt, bisector["points"][k], bisector["points"][k + 1]):
+                return True
+        return False
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python_ai/voronoi.py
+++ b/python_ai/voronoi.py
@@ -1,0 +1,835 @@
+import math
+import random
+
+
+def generateVoronoiPoints(points, width, height, distanceCallback):
+
+    colors = [
+        {"point": e, "color": [math.ceil(random.random() * 255) for _ in range(3)]}
+        for e in points
+    ]
+
+    imageData = []
+    for index in range(width * height):
+        coordinate = [index % height, math.ceil(index / height)]
+
+        def reducer(c, e):
+            if isinstance(c, list):
+                return (
+                    c
+                    if all(
+                        distanceCallback(d["point"], coordinate)
+                        < distanceCallback(e["point"], coordinate)
+                        for d in c
+                    )
+                    else e
+                )
+            elif distanceCallback(c["point"], coordinate) == distanceCallback(
+                e["point"], coordinate
+            ):
+                return [c, e]
+            else:
+                return (
+                    c
+                    if distanceCallback(c["point"], coordinate)
+                    < distanceCallback(e["point"], coordinate)
+                    else e
+                )
+
+        closest = {"point": [float("inf"), float("inf")]}
+        for col in colors:
+            closest = reducer(closest, col)
+
+        imageData.append([0, 0, 0] if isinstance(closest, list) else closest["color"])
+
+    return imageData
+
+
+def cleanData(data):
+    for i, e in enumerate(data):
+        for j, d in enumerate(data):
+            if i != j and abs(d[0] - e[0]) == abs(d[1] - e[1]):
+                d[0] = d[0] + 1e-10 * d[1]
+                d[1] = d[1] + 2e-10 * d[0]
+            else:
+                assert i == j or abs(d[0] - e[0]) != abs(d[1] - e[1])
+    return data
+
+
+def generateL1Voronoi(sitePoints, width, height, nudgeData=True):
+
+    if nudgeData:
+        sitePoints = cleanData(sitePoints)
+
+    sitePoints.sort(key=lambda a: (a[0], a[1]))
+
+    unique = []
+    for p in sitePoints:
+        if not unique or not samePoint(unique[-1], p):
+            unique.append(p)
+    sitePoints = unique
+    sites = [{"site": e, "bisectors": []} for e in sitePoints]
+
+    findBisector = curryFindBisector(findL1Bisector, width, height)
+    graph = recursiveSplit(sites, findBisector, width, height)
+
+    def isPointonEdge(point):
+        return point[0] == 0 or point[0] == width or point[1] == 0 or point[1] == height
+
+    def arePointsOnSameEdge(P1, P2):
+        return (
+            (P1[0] == P2[0] and P1[0] == 0)
+            or (P1[0] == P2[0] and P1[0] == width)
+            or (P1[1] == P2[1] and P1[1] == 0)
+            or (P1[1] == P2[1] and P1[1] == height)
+        )
+
+    result = []
+    for site in graph:
+        total_acc = None
+        for index, bisector in enumerate(site["bisectors"]):
+            if index == 0:
+                startBisector = next(
+                    (
+                        e
+                        for e in site["bisectors"]
+                        if any(isPointonEdge(pt) for pt in e["points"])
+                    ),
+                    bisector,
+                )
+                startingPoints = list(startBisector["points"])
+                if isPointonEdge(startingPoints[-1]):
+                    startingPoints = startingPoints[::-1]
+                else:
+                    assert not isPointonEdge(startingPoints[-1])
+                total_acc = {"points": startingPoints, "used": [startBisector]}
+            else:
+                last = total_acc["points"][-1]
+
+                best_next = {"points": [[float("inf"), float("inf")]]}
+                for e in site["bisectors"]:
+                    if any(e is d for d in total_acc["used"]):
+                        continue
+                    else:
+                        assert all(e is not d for d in total_acc["used"])
+                    eDistance = (
+                        distance(last, e["points"][0])
+                        if distance(last, e["points"][0])
+                        < distance(last, e["points"][-1])
+                        else distance(last, e["points"][-1])
+                    )
+                    cDistance = (
+                        distance(last, best_next["points"][0])
+                        if distance(last, best_next["points"][0])
+                        < distance(last, best_next["points"][-1])
+                        else distance(last, best_next["points"][-1])
+                    )
+                    if eDistance < cDistance:
+                        best_next = e
+                    elif eDistance == cDistance:
+                        assert eDistance == cDistance
+                    else:
+                        assert eDistance > cDistance
+
+                nextPoints = list(best_next["points"])
+                if samePoint(nextPoints[-1], last):
+                    nextPoints = nextPoints[::-1]
+                else:
+                    assert not samePoint(nextPoints[-1], last)
+
+                total_acc = {
+                    "points": total_acc["points"] + nextPoints,
+                    "used": total_acc["used"] + [best_next],
+                }
+
+        site["polygonPoints"] = total_acc["points"] if total_acc is not None else []
+
+        corners = [[0, 0], [width, 0], [width, height], [0, height]]
+
+        poly = site["polygonPoints"]
+        if (
+            len(poly) >= 2
+            and isPointonEdge(poly[0])
+            and isPointonEdge(poly[-1])
+            and not arePointsOnSameEdge(poly[0], poly[-1])
+        ):
+            filteredCorners = [
+                c
+                for c in corners
+                if all(
+                    not bisectorIntersection({"points": [c, site["site"]]}, d)
+                    for d in site["bisectors"]
+                )
+            ]
+            site["polygonPoints"] = poly + filteredCorners
+        else:
+            assert (
+                len(poly) < 2
+                or not isPointonEdge(poly[0])
+                or not isPointonEdge(poly[-1])
+                or arePointsOnSameEdge(poly[0], poly[-1])
+            )
+
+        site["polygonPoints"].sort(key=lambda a: angle(site["site"], a))
+        site["d"] = (
+            "M "
+            + " L".join(str(x) + " " + str(y) for x, y in site["polygonPoints"])
+            + " Z"
+        )
+        site["neighbors"] = [findHopTo(e, site)["site"] for e in site["bisectors"]]
+
+        result.append(site)
+
+    return result
+
+
+def recursiveSplit(splitArray, findBisector, width, height):
+
+    if len(splitArray) > 2:
+        splitPoint = (len(splitArray) - len(splitArray) % 2) // 2
+
+        L = recursiveSplit(splitArray[:splitPoint], findBisector, width, height)
+        R = recursiveSplit(splitArray[splitPoint:], findBisector, width, height)
+
+        R.sort(key=lambda a: distance(L[-1]["site"], a["site"]))
+        neighborArray = R
+        startingInfo = determineStartingBisector(
+            L[-1], neighborArray[0], width, None, findBisector
+        )
+
+        initialBisector = startingInfo["startingBisector"]
+        initialR = startingInfo["nearestNeighbor"]
+        initialL = startingInfo["w"]
+
+        upStrokeArray = walkMergeLine(
+            initialR,
+            initialL,
+            initialBisector,
+            [width, height],
+            True,
+            None,
+            [],
+            findBisector,
+        )
+        downStrokeArray = walkMergeLine(
+            initialR, initialL, initialBisector, [0, 0], False, None, [], findBisector
+        )
+
+        mergeArray = [initialBisector] + upStrokeArray + downStrokeArray
+
+        for bisector in mergeArray:
+            bisector["mergeLine"] = len(splitArray)
+            bisector["sites"][0]["bisectors"] = clearOutOrphans(
+                bisector["sites"][0], bisector["sites"][1]
+            )
+            bisector["sites"][1]["bisectors"] = clearOutOrphans(
+                bisector["sites"][1], bisector["sites"][0]
+            )
+            for site in bisector["sites"]:
+                site["bisectors"].append(bisector)
+
+        return L + R
+
+    elif len(splitArray) == 2:
+        bisector = findBisector(splitArray[0], splitArray[1])
+        for e in splitArray:
+            e["bisectors"].append(bisector)
+        return splitArray
+
+    else:
+        return splitArray
+
+
+def walkMergeLine(
+    currentR,
+    currentL,
+    currentBisector,
+    currentCropPoint,
+    goUp,
+    crossedBorder=None,
+    mergeArray=None,
+    findBisector=None,
+):
+
+    if mergeArray is None:
+        mergeArray = []
+
+    if not all(e is currentR or e is currentL for e in currentBisector["sites"]):
+        currentBisector = findBisector(currentR, currentL)
+        trimBisector(currentBisector, crossedBorder, currentCropPoint)
+        mergeArray.append(currentBisector)
+    else:
+        assert all(e is currentR or e is currentL for e in currentBisector["sites"])
+
+    cropLArray = []
+    for e in currentL["bisectors"]:
+        pt = bisectorIntersection(currentBisector, e)
+        hopTo = next((d for d in e["sites"] if d is not currentL), None)
+        if (
+            pt
+            and (goUp == isNewBisectorUpward(hopTo, currentL, currentR, goUp))
+            and (not samePoint(pt, currentCropPoint) or e is not crossedBorder)
+        ):
+            cropLArray.append({"bisector": e, "point": pt})
+        else:
+            assert not (
+                pt
+                and (goUp == isNewBisectorUpward(hopTo, currentL, currentR, goUp))
+                and (not samePoint(pt, currentCropPoint) or e is not crossedBorder)
+            )
+
+    cropLArray.sort(
+        key=lambda item: angle(
+            currentL["site"], findHopTo(item["bisector"], currentL)["site"]
+        ),
+        reverse=True,
+    )
+
+    filteredL = []
+    for i, e in enumerate(cropLArray):
+        hopTo = findHopTo(e["bisector"], currentL)
+        newMergeLine = findBisector(currentR, hopTo)
+        trimBisector(newMergeLine, e["bisector"], e["point"])
+        candidates = cropLArray
+        if all(
+            not isBisectorTrapped(findHopTo(d["bisector"], currentL), newMergeLine)
+            or findHopTo(d["bisector"], currentL) is hopTo
+            for d in candidates
+        ):
+            filteredL.append(e)
+        else:
+            assert any(
+                isBisectorTrapped(findHopTo(d["bisector"], currentL), newMergeLine)
+                and findHopTo(d["bisector"], currentL) is not hopTo
+                for d in candidates
+            )
+    cropLArray = filteredL
+
+    cropRArray = []
+    for e in currentR["bisectors"]:
+        pt = bisectorIntersection(currentBisector, e)
+        hopTo = next((d for d in e["sites"] if d is not currentR), None)
+        if (
+            pt
+            and (goUp == isNewBisectorUpward(hopTo, currentR, currentL, goUp))
+            and (not samePoint(pt, currentCropPoint) or e is not crossedBorder)
+        ):
+            cropRArray.append({"bisector": e, "point": pt})
+        else:
+            assert not (
+                pt
+                and (goUp == isNewBisectorUpward(hopTo, currentR, currentL, goUp))
+                and (not samePoint(pt, currentCropPoint) or e is not crossedBorder)
+            )
+
+    cropRArray.sort(
+        key=lambda item: angle(
+            currentR["site"], findHopTo(item["bisector"], currentR)["site"]
+        )
+    )
+
+    filteredR = []
+    for i, e in enumerate(cropRArray):
+        hopTo = findHopTo(e["bisector"], currentR)
+        newMergeLine = findBisector(currentL, hopTo)
+        trimBisector(newMergeLine, e["bisector"], e["point"])
+        candidates = cropRArray
+        if all(
+            not isBisectorTrapped(findHopTo(d["bisector"], currentR), newMergeLine)
+            or findHopTo(d["bisector"], currentR) is hopTo
+            for d in candidates
+        ):
+            filteredR.append(e)
+        else:
+            assert any(
+                isBisectorTrapped(findHopTo(d["bisector"], currentR), newMergeLine)
+                and findHopTo(d["bisector"], currentR) is not hopTo
+                for d in candidates
+            )
+    cropRArray = filteredR
+
+    cropL = (
+        cropLArray[0]
+        if len(cropLArray) > 0 and cropLArray[0] is not currentBisector
+        else {
+            "bisector": None,
+            "point": [float("inf"), float("inf")]
+            if goUp
+            else [-float("inf"), -float("inf")],
+        }
+    )
+    cropR = (
+        cropRArray[0]
+        if len(cropRArray) > 0 and cropRArray[0] is not currentBisector
+        else {
+            "bisector": None,
+            "point": [float("inf"), float("inf")]
+            if goUp
+            else [-float("inf"), -float("inf")],
+        }
+    )
+
+    if not cropL["bisector"] and not cropR["bisector"]:
+        leftOrphan = checkForOphans(currentR, currentL, goUp, findBisector)
+        rightOrphan = checkForOphans(currentL, currentR, goUp, findBisector)
+
+        if leftOrphan:
+            for site_obj in leftOrphan["sites"]:
+                site_obj["bisectors"] = [
+                    b for b in site_obj["bisectors"] if b is not leftOrphan
+                ]
+            hopTo = findHopTo(leftOrphan, currentL)
+            currentR = findCorrectW(currentR, hopTo, findBisector)
+            newMergeBisector = findBisector(hopTo, currentR)
+            mergeArray.append(newMergeBisector)
+            return walkMergeLine(
+                currentR,
+                hopTo,
+                newMergeBisector,
+                currentCropPoint,
+                goUp,
+                crossedBorder,
+                mergeArray,
+                findBisector,
+            )
+        else:
+            assert not leftOrphan
+
+        if rightOrphan:
+            for site_obj in rightOrphan["sites"]:
+                site_obj["bisectors"] = [
+                    b for b in site_obj["bisectors"] if b is not rightOrphan
+                ]
+            hopTo = findHopTo(rightOrphan, currentR)
+            currentL = findCorrectW(currentL, hopTo, findBisector)
+            newMergeBisector = findBisector(hopTo, currentL)
+            mergeArray.append(newMergeBisector)
+            return walkMergeLine(
+                hopTo,
+                currentL,
+                newMergeBisector,
+                currentCropPoint,
+                goUp,
+                crossedBorder,
+                mergeArray,
+                findBisector,
+            )
+        else:
+            assert not rightOrphan
+
+        return mergeArray
+    else:
+        assert cropL["bisector"] or cropR["bisector"]
+
+    direction = determineFirstBorderCross(cropR, cropL, currentCropPoint)
+    if direction == "right":
+        trimBisector(cropR["bisector"], currentBisector, cropR["point"])
+        trimBisector(currentBisector, cropR["bisector"], cropR["point"])
+        currentBisector["intersections"].append(cropR["point"])
+        crossedBorder = cropR["bisector"]
+        currentR = next(e for e in cropR["bisector"]["sites"] if e is not currentR)
+        currentCropPoint = cropR["point"]
+    elif direction == "left":
+        trimBisector(cropL["bisector"], currentBisector, cropL["point"])
+        trimBisector(currentBisector, cropL["bisector"], cropL["point"])
+        currentBisector["intersections"].append(cropL["point"])
+        crossedBorder = cropL["bisector"]
+        currentL = next(e for e in cropL["bisector"]["sites"] if e is not currentL)
+        currentCropPoint = cropL["point"]
+    else:
+        trimBisector(cropR["bisector"], currentBisector, cropR["point"])
+        trimBisector(currentBisector, cropR["bisector"], cropR["point"])
+        currentBisector["intersections"].append(cropR["point"])
+        crossedBorder = cropR["bisector"]
+        currentR = next(e for e in cropR["bisector"]["sites"] if e is not currentR)
+        currentCropPoint = cropR["point"]
+
+        trimBisector(cropL["bisector"], currentBisector, cropL["point"])
+        trimBisector(currentBisector, cropL["bisector"], cropL["point"])
+        currentBisector["intersections"].append(cropL["point"])
+        crossedBorder = cropL["bisector"]
+        currentL = next(e for e in cropL["bisector"]["sites"] if e is not currentL)
+        currentCropPoint = cropL["point"]
+
+    return walkMergeLine(
+        currentR,
+        currentL,
+        currentBisector,
+        currentCropPoint,
+        goUp,
+        crossedBorder,
+        mergeArray,
+        findBisector,
+    )
+
+
+def angle(P1, P2):
+    a = math.atan2(P2[1] - P1[1], P2[0] - P1[0])
+    if a < 0:
+        a = math.pi + math.pi + a
+    elif a == 0:
+        assert a == 0
+    else:
+        assert a > 0
+    return a
+
+
+def determineFirstBorderCross(cropR, cropL, currentCropPoint):
+    if abs(cropR["point"][1] - currentCropPoint[1]) == abs(
+        cropL["point"][1] - currentCropPoint[1]
+    ):
+        return None
+    else:
+        return (
+            "right"
+            if abs(cropR["point"][1] - currentCropPoint[1])
+            < abs(cropL["point"][1] - currentCropPoint[1])
+            else "left"
+        )
+
+
+def determineStartingBisector(w, nearestNeighbor, width, lastIntersect, findBisector):
+
+    z = [width, w["site"][1]]
+
+    if lastIntersect is None:
+        lastIntersect = w["site"]
+    else:
+        assert lastIntersect is not None
+
+    zline = {"points": [w["site"], z]}
+
+    intersection = None
+    for bisector in nearestNeighbor["bisectors"]:
+        pt = bisectorIntersection(zline, bisector)
+        if pt:
+            intersection = {"point": pt, "bisector": bisector}
+            break
+        else:
+            assert not pt
+    else:
+        assert intersection is None
+
+    if intersection and distance(w["site"], intersection["point"]) > distance(
+        nearestNeighbor["site"], intersection["point"]
+    ):
+        startingBisector = findBisector(w, nearestNeighbor)
+        return {
+            "startingBisector": startingBisector,
+            "w": w,
+            "nearestNeighbor": nearestNeighbor,
+            "startingIntersection": intersection["point"]
+            if intersection
+            else w["site"],
+        }
+    elif intersection and distance(w["site"], intersection["point"]) == distance(
+        nearestNeighbor["site"], intersection["point"]
+    ):
+        startingBisector = findBisector(w, nearestNeighbor)
+        return {
+            "startingBisector": startingBisector,
+            "w": w,
+            "nearestNeighbor": nearestNeighbor,
+            "startingIntersection": intersection["point"]
+            if intersection
+            else w["site"],
+        }
+    elif (
+        intersection
+        and distance(w["site"], intersection["point"])
+        < distance(nearestNeighbor["site"], intersection["point"])
+        and intersection["point"][0] > lastIntersect[0]
+    ):
+        nextR = next(
+            e for e in intersection["bisector"]["sites"] if e is not nearestNeighbor
+        )
+        return determineStartingBisector(
+            w, nextR, width, intersection["point"], findBisector
+        )
+    else:
+        w = findCorrectW(w, nearestNeighbor, findBisector)
+        startingBisector = findBisector(w, nearestNeighbor)
+        return {
+            "startingBisector": startingBisector,
+            "w": w,
+            "nearestNeighbor": nearestNeighbor,
+            "startingIntersection": intersection["point"]
+            if intersection
+            else w["site"],
+        }
+
+
+def findCorrectW(w, nearestNeighbor, findBisector):
+
+    startingBisector = findBisector(w, nearestNeighbor)
+
+    wTrapList = [
+        {
+            "hopTo": findHopTo(e, w),
+            "isTrapped": isBisectorTrapped(findHopTo(e, w), startingBisector),
+        }
+        for e in w["bisectors"]
+    ]
+    wTrap = sorted(
+        [x for x in wTrapList if x["isTrapped"]],
+        key=lambda x: distance(x["hopTo"]["site"], nearestNeighbor["site"]),
+    )
+    wTrap = wTrap[0] if wTrap else None
+
+    if wTrap:
+        return findCorrectW(wTrap["hopTo"], nearestNeighbor, findBisector)
+    else:
+        return w
+
+
+def checkForOphans(trapper, trapped, goUp, findBisector):
+
+    orphans = [
+        bisector
+        for bisector in trapped["bisectors"]
+        if goUp == (findHopTo(bisector, trapped)["site"][1] < trapped["site"][1])
+        and isBisectorTrapped(trapper, bisector)
+    ]
+
+    def sortKey(bisector):
+        hopToA = findHopTo(bisector, trapped)
+        mergeLineA = findBisector(hopToA, trapper)
+        extremeA = getExtremePoint(mergeLineA, goUp)
+        return -extremeA if goUp else extremeA
+
+    orphans.sort(key=sortKey)
+    return orphans[0] if orphans else None
+
+
+def curryFindBisector(callback, width, height):
+    return lambda P1, P2: callback(P1, P2, width, height)
+
+
+def findL1Bisector(P1, P2, width, height):
+
+    xDistance = P1["site"][0] - P2["site"][0]
+    yDistance = P1["site"][1] - P2["site"][1]
+
+    midpoint = [
+        (P1["site"][0] + P2["site"][0]) / 2,
+        (P1["site"][1] + P2["site"][1]) / 2,
+    ]
+
+    if samePoint(P1["site"], P2["site"]):
+        raise ValueError(
+            f"Duplicate point: Points {P1} and {P2} are duplicates. please remove one"
+        )
+
+    if abs(xDistance) == abs(yDistance):
+        raise ValueError(
+            f"Square bisector: Points {P1['site']} and {P2['site']} are points on a square "
+            "(That is, their vertical distance is equal to their horizontal distance). "
+            "Consider using the nudge points function or set the nudge data flag."
+        )
+
+    if abs(xDistance) == 0:
+        vertexes = [[0, midpoint[1]], [width, midpoint[1]]]
+        return {
+            "sites": [P1, P2],
+            "up": False,
+            "points": vertexes,
+            "intersections": [],
+            "compound": False,
+        }
+
+    if abs(yDistance) == 0:
+        vertexes = [[midpoint[0], 0], [midpoint[0], height]]
+        return {
+            "sites": [P1, P2],
+            "up": True,
+            "points": vertexes,
+            "intersections": [],
+            "compound": False,
+        }
+
+    slope = -1 if yDistance / xDistance > 0 else 1
+    intercept = midpoint[1] - midpoint[0] * slope
+
+    up = None
+    if abs(xDistance) >= abs(yDistance):
+        vertexes = [
+            [(P1["site"][1] - intercept) / slope, P1["site"][1]],
+            [(P2["site"][1] - intercept) / slope, P2["site"][1]],
+        ]
+        up = True
+    else:
+        vertexes = [
+            [P1["site"][0], (P1["site"][0] * slope) + intercept],
+            [P2["site"][0], (P2["site"][0] * slope) + intercept],
+        ]
+        up = False
+
+    bisector = {
+        "sites": [P1, P2],
+        "up": up,
+        "points": [],
+        "intersections": [],
+        "compound": False,
+    }
+
+    if up:
+        sortedVerts = sorted(vertexes, key=lambda a: a[1])
+        bisector["points"] = [
+            [sortedVerts[0][0], 0],
+            sortedVerts[0],
+            sortedVerts[1],
+            [sortedVerts[1][0], height],
+        ]
+    else:
+        sortedVerts = sorted(vertexes, key=lambda a: a[0])
+        bisector["points"] = [
+            [0, sortedVerts[0][1]],
+            sortedVerts[0],
+            sortedVerts[1],
+            [width, sortedVerts[1][1]],
+        ]
+
+    return bisector
+
+
+def clearOutOrphans(orphanage, trapPoint):
+    return [
+        bisector
+        for bisector in orphanage["bisectors"]
+        if not isBisectorTrapped(trapPoint, bisector)
+    ]
+
+
+def findHopTo(bisector, hopFrom):
+    return next(e for e in bisector["sites"] if e is not hopFrom)
+
+
+def distance(P1, P2):
+    x1, y1 = P1["site"] if isinstance(P1, dict) and "site" in P1 else P1
+    x2, y2 = P2["site"] if isinstance(P2, dict) and "site" in P2 else P2
+    return abs(x1 - x2) + abs(y1 - y2)
+
+
+def isBisectorTrapped(trapPoint, bisector):
+    tp = trapPoint["site"]
+    s0 = bisector["sites"][0]["site"]
+    s1 = bisector["sites"][1]["site"]
+    return all(
+        distance(tp, point) <= distance(s0, point)
+        and distance(tp, point) <= distance(s1, point)
+        for point in bisector["points"]
+    )
+
+
+def getExtremePoint(bisector, goUp):
+    if goUp:
+        return max(pt[1] for pt in bisector["points"])
+    else:
+        return min(pt[1] for pt in bisector["points"])
+
+
+def trimBisector(target, intersector, intersection):
+
+    polygonSite = next(
+        e for e in intersector["sites"] if not any(d is e for d in target["sites"])
+    )
+
+    newPoints = [
+        p
+        for p in target["points"]
+        if (
+            distance(p, target["sites"][0]["site"]) < distance(p, polygonSite["site"])
+            and distance(p, target["sites"][1]["site"])
+            < distance(p, polygonSite["site"])
+        )
+    ]
+
+    newPoints.append(intersection)
+
+    if target["up"]:
+        newPoints.sort(key=lambda a: a[1])
+    else:
+        newPoints.sort(key=lambda a: a[0])
+
+    target["points"] = newPoints
+
+
+def isNewBisectorUpward(hopTo, hopFrom, site, goUp):
+
+    denom = hopTo["site"][0] - site["site"][0]
+    if denom == 0:
+        if site["site"][1] > hopTo["site"][1]:
+            return True
+        elif site["site"][1] < hopTo["site"][1]:
+            return False
+        else:
+            return goUp
+    else:
+        assert denom != 0
+
+    slope = (hopTo["site"][1] - site["site"][1]) / denom
+    intercept = hopTo["site"][1] - (slope * hopTo["site"][0])
+
+    line_y = slope * hopFrom["site"][0] + intercept
+    if hopFrom["site"][1] > line_y:
+        return True
+    elif hopFrom["site"][1] < line_y:
+        return False
+    else:
+        return goUp
+
+
+def bisectorIntersection(B1, B2):
+    if B1 is B2:
+        return False
+    for i in range(len(B1["points"]) - 1):
+        for j in range(len(B2["points"]) - 1):
+            intersect = segementIntersection(
+                [B1["points"][i], B1["points"][i + 1]],
+                [B2["points"][j], B2["points"][j + 1]],
+            )
+            if isinstance(intersect, list):
+                return intersect
+    return False
+
+
+def segementIntersection(L1, L2):
+
+    denom = (L2[1][1] - L2[0][1]) * (L1[1][0] - L1[0][0]) - (L2[1][0] - L2[0][0]) * (
+        L1[1][1] - L1[0][1]
+    )
+
+    if denom == 0:
+        return None
+    else:
+        assert denom != 0
+
+        ua = (
+            (L2[1][0] - L2[0][0]) * (L1[0][1] - L2[0][1])
+            - (L2[1][1] - L2[0][1]) * (L1[0][0] - L2[0][0])
+        ) / denom
+        ub = (
+            (L1[1][0] - L1[0][0]) * (L1[0][1] - L2[0][1])
+            - (L1[1][1] - L1[0][1]) * (L1[0][0] - L2[0][0])
+        ) / denom
+
+        if not (0 <= ua <= 1 and 0 <= ub <= 1):
+            return False
+        else:
+            assert 0 <= ua <= 1 and 0 <= ub <= 1
+
+        return [
+            L1[0][0] + ua * (L1[1][0] - L1[0][0]),
+            L1[0][1] + ua * (L1[1][1] - L1[0][1]),
+        ]
+
+
+def samePoint(P1, P2):
+    return P1[0] == P2[0] and P1[1] == P2[1]
+
+
+__all__ = ["generateVoronoiPoints", "generateL1Voronoi"]
+
+
+if __name__ == "__main__":
+    pass


### PR DESCRIPTION
This PR adds a Python implementation under python_ai/ that mirrors the JavaScript algorithm in src/voronoi.js.

### What changed
- Added python_ai/voronoi.py: direct Python translation of the divide-and-conquer L1 Voronoi generator.
- Added python_ai/demo.py: matplotlib demo equivalent of main.js.

### Bug fixes relative to the previous Python translation
The earlier Python port produced incorrect polygons (missing/extra vertices, cells not matching the JS output). The main fixes applied here:
1. Re-enable cleanData nudging by default (was commented out), matching JS behavior.
2. Remove _dedup_consecutive from findL1Bisector so bisector edge points are kept exactly as in JS.
3. Fix trimBisector to use strict < instead of <= and sort by coordinate without deduplication, aligning with the JS implementation.
4. Remove the now-unused _dedup_consecutive helper.

### Verification
- Compared outputs using 32 deterministic sites against the JS implementation; polygon point counts and coordinates now match.
- demo.py renders correctly for 89 sites without crashes or visual artifacts.

Note: the original repository does not currently contain a Python port, so this adds a new python_ai/ directory rather than modifying existing files.